### PR TITLE
Maven wrapper: fix version propagation, checksums, credentials, and align with plugin docs

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,7 +14,8 @@ concurrency:
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  SMOKE_TEST_BRANCH: maven-wrapper
+  SMOKE_TEST_BRANCH: ${{ vars.SMOKE_TEST_BRANCH || 'maven-wrapper' }}
+  SMOKE_TEST_REPO: ${{ vars.SMOKE_TEST_REPO || 'yeikel/smoke-tests' }}
 permissions: {}
 
 jobs:
@@ -49,7 +50,7 @@ jobs:
           cat filtered.json
 
           # Curl the smoke-test tests directory to get a list of tests to run
-          URL=https://api.github.com/repos/${{ vars.SMOKE_TEST_REPO || 'yeikel/smoke-tests' }}/contents/tests?ref=${{ env.SMOKE_TEST_BRANCH }}
+          URL=https://api.github.com/repos/${{ env.SMOKE_TEST_REPO }}/contents/tests?ref=${{ env.SMOKE_TEST_BRANCH }}
           curl $URL > tests.json
 
           # Select the names that match smoke-$test*.yaml, where $test is the .text value from filtered.json
@@ -97,7 +98,7 @@ jobs:
       - name: Download test
         if: steps.cache-smoke-test.outputs.cache-hit != 'true'
         run: |
-          gh api "repos/${{ vars.SMOKE_TEST_REPO || 'yeikel/smoke-tests' }}/contents/tests/${{ matrix.suite.name }}?ref=maven-wrapper" -H "Accept: application/vnd.github.raw" > smoke.yaml
+          gh api "repos/${{ env.SMOKE_TEST_REPO }}/contents/tests/${{ matrix.suite.name }}?ref=${{ env.SMOKE_TEST_BRANCH }}" -H "Accept: application/vnd.github.raw" > smoke.yaml
 
       - name: Cache Smoke Test
         if: steps.cache-smoke-test.outputs.cache-hit != 'true'
@@ -117,7 +118,7 @@ jobs:
           CACHE=${CACHE%.yaml}
           CACHE=${CACHE%.yml}
 
-          gh run download --repo yeikel/smoke-tests --name cache-$CACHE --dir cache
+          gh run download --repo ${{ env.SMOKE_TEST_REPO }} --name cache-$CACHE --dir cache
         continue-on-error: true
 
       - name: Build ecosystem image

--- a/maven/lib/dependabot/maven/file_fetcher.rb
+++ b/maven/lib/dependabot/maven/file_fetcher.rb
@@ -76,7 +76,9 @@ module Dependabot
           files << f if f
         end
 
-        dist_type = FileParser::WrapperMojo.resolve_distribution_type(T.must(properties.content))
+        content = T.must(properties.content)
+        wrapper_url = FileParser::WrapperMojo.get_property_value(content, "wrapperUrl")
+        dist_type = FileParser::WrapperMojo.resolve_distribution_type(content, wrapper_url)
         files + fetch_wrapper_artifact_files(dir, dist_type)
       rescue Dependabot::DependencyFileNotFound
         []

--- a/maven/lib/dependabot/maven/file_parser.rb
+++ b/maven/lib/dependabot/maven/file_parser.rb
@@ -97,7 +97,8 @@ module Dependabot
 
         if Dependabot::Experiments.enabled?(:maven_wrapper_updater)
           wrapper_properties_files.each do |properties_file|
-            dir = File.dirname(properties_file.name).sub(%r{/\.mvn/wrapper$}, "")
+            dir = File.dirname(properties_file.name).sub(%r{/?\.mvn/wrapper$}, "")
+            dir = "." if dir.empty?
             scripts = wrapper_script_files_for(dir)
             FileParser::WrapperMojo.resolve_dependencies(properties_file, script_files: scripts).each do |dep|
               dependency_set << dep

--- a/maven/lib/dependabot/maven/file_parser/wrapper_mojo.rb
+++ b/maven/lib/dependabot/maven/file_parser/wrapper_mojo.rb
@@ -225,9 +225,17 @@ module Dependabot
           )
         end
 
-        sig { params(content: String).returns(String) }
-        def self.resolve_distribution_type(content)
-          get_property_value(content, "distributionType") || "bin"
+        # Resolves the distribution type, matching the maven-wrapper-plugin's own precedence:
+        # an explicit distributionType wins; otherwise the plugin defaults to "only-script" (since
+        # 3.2.0). Legacy pre-3.3.0 files omit distributionType but carry a wrapperUrl pointing at the
+        # maven-wrapper JAR, which means a JAR-based ("bin") setup, so we keep that for them.
+        # https://maven.apache.org/tools/wrapper/maven-wrapper-plugin/wrapper-mojo.html
+        sig { params(content: String, wrapper_url: T.nilable(String)).returns(String) }
+        def self.resolve_distribution_type(content, wrapper_url)
+          explicit = get_property_value(content, "distributionType")
+          return explicit if explicit
+
+          wrapper_url ? "bin" : "only-script"
         end
 
         sig { params(script_files: T::Array[DependencyFile]).returns(T::Boolean) }
@@ -243,7 +251,7 @@ module Dependabot
           distribution_sha256_sum = get_property_value(content, "distributionSha256Sum")
           wrapper_url = get_property_value(content, "wrapperUrl")
           wrapper_sha256_sum = get_property_value(content, "wrapperSha256Sum")
-          distribution_type = resolve_distribution_type(content)
+          distribution_type = resolve_distribution_type(content, wrapper_url)
           wrapper_version = resolve_wrapper_version(content, wrapper_url, script_files)
 
           WrapperProperties.new(
@@ -274,9 +282,9 @@ module Dependabot
           # 2. Escape the key for Regex safety
           escaped_key = Regexp.escape(target_key)
 
-          # 3. Define the pattern:
-          # Start of line -> Key -> optional space -> delimiter (= or :) -> value
-          pattern = /^\s*#{escaped_key}\s*[=:]\s*(.*)$/
+          # Start of line -> Key -> optional space -> delimiter (= or :) -> value.
+          # Bounded to spaces/tabs (not \s) so the per-line match can't backtrack polynomially.
+          pattern = /^[ \t]*#{escaped_key}[ \t]*[=:][ \t]*(.*)$/
 
           normalized_content.lines.each do |line|
             next if line.start_with?("#", "!") # Skip Java comments

--- a/maven/lib/dependabot/maven/file_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater.rb
@@ -32,21 +32,68 @@ module Dependabot
       def collect_wrapper_updates
         return [] unless Dependabot::Experiments.enabled?(:maven_wrapper_updater)
 
-        buildfile = dependency_files.find { |f| f.name == "pom.xml" }
-        return [] unless buildfile
-
         updated = T.let([], T::Array[Dependabot::DependencyFile])
-        dependencies.each do |dependency|
-          next unless Distributions.distribution_requirements?(dependency.requirements)
+        # Group the distribution-type dependencies by the wrapper they belong to (its properties
+        # file). Each wrapper is regenerated exactly once, so a grouped distribution + wrapper-plugin
+        # update produces a single coherent set of files instead of duplicates, and module wrappers
+        # are updated in place rather than at the repo root.
+        wrapper_dependency_groups.each do |properties_name, group|
+          buildfile = build_file_for_wrapper(properties_name)
+          next unless buildfile
 
+          representative = group.find { |d| d.name == Distributions::MAVEN_DISTRIBUTION_PACKAGE } || T.must(group.first)
+          dist_version = resolve_group_version(group, Distributions::MAVEN_DISTRIBUTION_PACKAGE, :distribution_version)
+          wrap_version = resolve_group_version(group, Distributions::MAVEN_WRAPPER_PACKAGE, :wrapper_version)
           wu = WrapperUpdater.new(
             dependency_files: dependency_files,
-            dependency: dependency,
-            credentials: credentials
+            dependency: representative,
+            credentials: credentials,
+            distribution_version: dist_version,
+            wrapper_version: wrap_version
           )
           updated += wu.update_files(buildfile)
         end
         updated
+      end
+
+      # Groups the distribution-type dependencies by their wrapper properties file path.
+      sig { returns(T::Hash[T.nilable(String), T::Array[Dependabot::Dependency]]) }
+      def wrapper_dependency_groups
+        dependencies.select { |d| Distributions.distribution_requirements?(d.requirements) }
+                    .group_by do |dep|
+          dep.requirements
+             .find { |r| r.dig(:source, :type) == Distributions::DISTRIBUTION_DEPENDENCY_TYPE }
+             &.fetch(:file, nil)
+        end
+      end
+
+      # Finds the pom.xml that owns a wrapper, so the native command runs in the wrapper's directory.
+      sig { params(properties_name: T.nilable(String)).returns(T.nilable(Dependabot::DependencyFile)) }
+      def build_file_for_wrapper(properties_name)
+        dir = File.dirname(properties_name.to_s).sub(%r{/?\.mvn/wrapper\z}, "")
+        pom_name = dir.empty? ? "pom.xml" : File.join(dir, "pom.xml")
+        dependency_files.find { |f| f.name == pom_name } ||
+          dependency_files.find { |f| f.name == "pom.xml" }
+      end
+
+      # Resolves the effective version for a group, preferring the dependency that actually owns the
+      # coordinate (so a grouped update uses each dependency's own new version) and falling back to the
+      # unchanged value carried on any group member.
+      sig do
+        params(group: T::Array[Dependabot::Dependency], package: String, metadata_key: Symbol)
+          .returns(T.nilable(String))
+      end
+      def resolve_group_version(group, package, metadata_key)
+        owner = group.find { |d| d.name == package }
+        version_from_metadata(owner, metadata_key) ||
+          group.filter_map { |d| version_from_metadata(d, metadata_key) }.first
+      end
+
+      sig { params(dep: T.nilable(Dependabot::Dependency), key: Symbol).returns(T.nilable(String)) }
+      def version_from_metadata(dep, key)
+        return nil unless dep
+
+        dep.requirements.find { |r| r.dig(:metadata, key) }&.dig(:metadata, key)
       end
 
       sig { returns(T::Array[Dependabot::DependencyFile]) }

--- a/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
+++ b/maven/lib/dependabot/maven/file_updater/wrapper_updater.rb
@@ -37,13 +37,20 @@ module Dependabot
           params(
             dependency_files: T::Array[DependencyFile],
             dependency: Dependency,
-            credentials: T::Array[Dependabot::Credential]
+            credentials: T::Array[Dependabot::Credential],
+            distribution_version: T.nilable(String),
+            wrapper_version: T.nilable(String)
           ).void
         end
-        def initialize(dependency_files:, dependency:, credentials:)
+        def initialize(dependency_files:, dependency:, credentials:, distribution_version: nil, wrapper_version: nil)
           @dependency_files = dependency_files
           @dependency       = dependency
           @credentials      = credentials
+          # Optional resolved versions. When a grouped update bumps both the distribution and the
+          # wrapper plugin, neither dependency alone carries both new versions, so the caller resolves
+          # them and passes them in. When nil we fall back to reading them from the dependency.
+          @distribution_version_override = distribution_version
+          @wrapper_version_override      = wrapper_version
         end
 
         # Entry point. Updates the wrapper properties file in-place, then
@@ -55,13 +62,18 @@ module Dependabot
           return [] unless Distributions.distribution_requirements?(dependency.requirements)
           return [] unless wrapper_properties_file
 
+          # Capture the user's original properties before we mutate the on-disk copy, so we can
+          # tell which checksums they were tracking and restore exactly those afterwards.
+          original_properties = wrapper_properties_file&.content
+
           SharedHelpers.in_a_temporary_directory(project_root(buildfile)) do
             write_dependency_files
 
             # Drop both SHA-256 checksum properties before invoking the native command.
             # If they remain, Maven verifies the old checksum against the new version and fails.
-            # The checksums cannot be passed in during generation because the wrapper does not support it.
-            # As a workaround, we recompute and re-add them once the generation completes
+            # We recompute and restore them afterwards: the plugin can accept -DdistributionSha256Sum /
+            # -DwrapperSha256Sum, but it does not derive the value for us, and Maven Central only
+            # publishes SHA-512, so we must download the artifact and compute the SHA-256 ourselves.
             strip_checksum_properties
 
             distribution_type = distribution_type_from_requirements
@@ -72,7 +84,7 @@ module Dependabot
             # But the wrapper only supports SHA-256 validation
             # We need compute the SHA-256 digest directly from the artifact
             # and write it into the regenerated properties file.
-            update_checksum_properties
+            restore_checksum_properties(original_properties)
 
             collect_updated_files(distribution_type)
           end
@@ -88,51 +100,49 @@ module Dependabot
         # new artifact without Maven aborting on a stale checksum mismatch.
         sig { void }
         def strip_checksum_properties
-          return unless File.exist?(WRAPPER_PROPERTIES_RELATIVE)
+          return unless File.exist?(properties_path)
 
-          content = File.read(WRAPPER_PROPERTIES_RELATIVE)
-          stripped = content.lines.reject { |l| l.match?(/\A(?:distribution|wrapper)Sha256Sum\s*=/) }.join
-          File.write(WRAPPER_PROPERTIES_RELATIVE, stripped)
+          content = File.read(properties_path)
+          stripped = content.lines.reject { |l| l.match?(/\A\s*(?:distribution|wrapper)Sha256Sum\s*[=:]/) }.join
+          File.write(properties_path, stripped)
         end
 
-        # Computes a fresh digest from the updated artifact
-        # This is needed because Maven Central only publishes SHA-512 checksums,
-        # while the wrapper only supports validations for the SHA-256
+        # Recomputes the SHA-256 checksums the user was already tracking and writes them onto the
+        # regenerated properties file. This is needed because Maven Central only publishes SHA-512
+        # checksums, while the wrapper only validates SHA-256, so the native command cannot produce
+        # them for us.
         #
-        # Raises if an expected artifact cannot be found in the cache, because
-        # a stale or missing checksum would silently weaken integrity checking.
-        sig { returns(T.nilable(Integer)) }
-        def update_checksum_properties
-          dist_req = dependency.requirements.find { |r| r[:source][:property] == "distributionUrl" }
-          wrapper_req = dependency.requirements.find { |r| r[:source][:property] == "wrapperUrl" }
+        # The URLs are read back from the *regenerated* properties file (not the dependency
+        # requirements), so this works no matter which coordinate was bumped: a wrapper-plugin bump
+        # still restores the distribution checksum, and a distribution bump still restores the wrapper
+        # checksum. We only restore checksums the user's original file actually contained, so we never
+        # add integrity properties the project did not opt into.
+        sig { params(original_properties: T.nilable(String)).void }
+        def restore_checksum_properties(original_properties)
+          return unless File.exist?(properties_path)
+          return if original_properties.nil?
 
-          dist_checksum = dist_req&.dig(:metadata, :distribution_sha256_sum)
-          wrapper_checksum = wrapper_req&.dig(:metadata, :wrapper_sha256_sum)
+          had_dist_checksum = property_present?(original_properties, "distributionSha256Sum")
+          had_wrapper_checksum = property_present?(original_properties, "wrapperSha256Sum")
 
-          Dependabot.logger.debug "updating checksum properties " \
-                                  "dist=#{!dist_checksum.nil?} wrap=#{!wrapper_checksum.nil?}"
-          return unless dist_checksum || wrapper_checksum
-          return unless File.exist?(WRAPPER_PROPERTIES_RELATIVE)
+          Dependabot.logger.debug "restoring checksum properties " \
+                                  "dist=#{had_dist_checksum} wrap=#{had_wrapper_checksum}"
+          return unless had_dist_checksum || had_wrapper_checksum
 
-          content = File.read(WRAPPER_PROPERTIES_RELATIVE)
+          content = File.read(properties_path)
 
-          if dist_checksum
-            dist_url = dist_req.dig(:source, :url)
-            content = set_checksum_from_url(
-              content,
-              "distributionSha256Sum",
-              T.cast(dist_url, String)
-            )
+          if had_dist_checksum && (dist_url = FileParser::WrapperMojo.get_property_value(content, "distributionUrl"))
+            content = set_checksum_from_url(content, "distributionSha256Sum", dist_url)
           end
-          if wrapper_checksum
-            wrapper_url = wrapper_req.dig(:source, :url)
-            content = set_checksum_from_url(
-              content,
-              "wrapperSha256Sum",
-              T.cast(wrapper_url, String)
-            )
+          if had_wrapper_checksum && (wrapper_url = FileParser::WrapperMojo.get_property_value(content, "wrapperUrl"))
+            content = set_checksum_from_url(content, "wrapperSha256Sum", wrapper_url)
           end
-          File.write(WRAPPER_PROPERTIES_RELATIVE, content)
+          File.write(properties_path, content)
+        end
+
+        sig { params(content: String, key: String).returns(T::Boolean) }
+        def property_present?(content, key)
+          !FileParser::WrapperMojo.get_property_value(content, key).nil?
         end
 
         sig { params(content: String, property_name: String, url: String).returns(String) }
@@ -151,7 +161,9 @@ module Dependabot
           end
 
           Dependabot.logger.info "Downloading Maven distribution: #{url} to calculate the sha256 checksum"
-          response = Dependabot::RegistryClient.get(url: url, headers: auth_headers_for_url(url))
+          # Registry auth is injected by Dependabot's proxy (which matches on host + path prefix),
+          # so we deliberately send no auth headers here — core never receives usable credentials.
+          response = Dependabot::RegistryClient.get(url: url)
           raise_on_auth_failure(url, response)
 
           raise "Failed to download #{url}: HTTP #{response.status}" unless response.status == 200
@@ -175,31 +187,16 @@ module Dependabot
           raise Dependabot::PrivateSourceAuthenticationFailure, repository_url
         end
 
-        sig { params(url: String).returns(T::Hash[String, String]) }
-        def auth_headers_for_url(url)
-          Dependabot.logger.debug "Building auth headers for: #{url}"
-
-          cred = maven_registry_credential(url)
-          unless cred
-            Dependabot.logger.debug "No matching credential found for #{url}, using no auth"
-            return {}
-          end
-
-          username = cred["username"]
-          password = cred["password"]
-          unless username
-            Dependabot.logger.debug "Credential for #{url} has no username, using no auth"
-            return {}
-          end
-
-          Dependabot.logger.debug "Using Basic auth for #{url} (username: #{username})"
-          { "Authorization" => "Basic #{Base64.strict_encode64("#{username}:#{password}")}" }
-        end
-
         sig { params(content: String, key: String, value: String).returns(String) }
         def set_checksum_property(content, key, value)
-          Dependabot.logger.debug "Appending #{key}"
-          "#{content.rstrip}\n#{key}=#{value}\n"
+          pattern = /^[ \t]*#{Regexp.escape(key)}[ \t]*[=:].*$/
+          if content.match?(pattern)
+            Dependabot.logger.debug "Replacing #{key}"
+            content.sub(pattern, "#{key}=#{value}")
+          else
+            Dependabot.logger.debug "Appending #{key}"
+            "#{content.rstrip}\n#{key}=#{value}\n"
+          end
         end
 
         sig { params(distribution_type: String).void }
@@ -212,12 +209,15 @@ module Dependabot
             wrapper_plugin_version: wrapper_version,
             env: build_env,
             distribution_type: distribution_type,
-            extra_args: extra_args
+            extra_args: extra_args,
+            cwd: wrapper_dir
           )
         end
 
         sig { returns(String) }
         def maven_wrapper_version_from_requirements
+          return T.must(@wrapper_version_override) if @wrapper_version_override
+
           wrapper_version = dependency.requirements
                                       .find { |r| r.dig(:metadata, :wrapper_version) }
                                       &.dig(:metadata, :wrapper_version)
@@ -228,6 +228,8 @@ module Dependabot
 
         sig { returns(String) }
         def distribution_version_from_requirements
+          return T.must(@distribution_version_override) if @distribution_version_override
+
           distribution_version = dependency.requirements
                                            .find { |r| r.dig(:metadata, :distribution_version) }
                                            &.dig(:metadata, :distribution_version)
@@ -252,12 +254,17 @@ module Dependabot
           include_debug = dependency.requirements
                                     .find { |r| r.dig(:metadata, :include_debug_script) }
                                     &.dig(:metadata, :include_debug_script)
-          args << "-DincludeDebugScript=true" if include_debug
+          # The plugin exposes this via the `includeDebug` user property (the field is named
+          # includeDebugScript internally). Passing -DincludeDebugScript is silently ignored, which
+          # would drop the user's mvnwDebug scripts on every update.
+          # https://maven.apache.org/tools/wrapper/maven-wrapper-plugin/wrapper-mojo.html
+          args << "-DincludeDebug=true" if include_debug
           args
         end
 
-        # Builds the environment hash passed to the native wrapper command,
-        # including proxy, registry URL, and credentials.
+        # Builds the environment hash passed to the native wrapper command.
+        # Sets the proxy host and, for a private/mirror registry, MVNW_REPOURL. Registry auth is
+        # injected by Dependabot's proxy, so no username/password is set here (core never receives them).
         sig { returns(T::Hash[String, String]) }
         def build_env
           env = T.let({}, T::Hash[String, String])
@@ -269,13 +276,10 @@ module Dependabot
 
           registry_base, cred = resolve_registry_base_and_credential
           env.merge!(build_registry_env(registry_base, cred))
-          env.merge!(build_credential_env(cred))
 
           if Dependabot.logger.debug?
             env["MVNW_VERBOSE"] = "true"
-            safe_env = env.except("MVNW_PASSWORD")
-            safe_env["MVNW_PASSWORD"] = "[REDACTED]" if env.key?("MVNW_PASSWORD")
-            Dependabot.logger.debug "build_env result: #{safe_env}"
+            Dependabot.logger.debug "build_env result: #{env}"
           end
 
           env
@@ -306,21 +310,11 @@ module Dependabot
         def build_registry_env(registry_base, cred)
           if registry_base
             { "MVNW_REPOURL" => registry_base }
-          elsif cred&.fetch("replaces_base", false)
+          elsif cred&.replaces_base?
             { "MVNW_REPOURL" => cred.fetch("url").chomp("/") }
           else
             {}
           end
-        end
-
-        sig { params(cred: T.nilable(Dependabot::Credential)).returns(T::Hash[String, String]) }
-        def build_credential_env(cred)
-          return {} unless cred
-
-          env = T.let({}, T::Hash[String, String])
-          env["MVNW_USERNAME"] = T.must(cred["username"]) if cred["username"]
-          env["MVNW_PASSWORD"] = T.must(cred["password"]) if cred["password"]
-          env
         end
 
         sig { params(registry_base: T.nilable(String)).returns(T.nilable(Dependabot::Credential)) }
@@ -335,12 +329,49 @@ module Dependabot
             return url_matches.max_by { |c| c.fetch("url", "").length } if url_matches.any?
           end
 
-          maven_creds.find { |c| c.fetch("replaces_base", false) }
+          maven_creds.find(&:replaces_base?)
         end
 
         sig { params(buildfile: DependencyFile).returns(String) }
         def project_root(buildfile)
-          File.dirname(buildfile.path)
+          # Always materialise the repo relative to its root; per-wrapper working directories are
+          # handled via `wrapper_dir` (the mvn command runs there and files are read/written there).
+          buildfile.directory
+        end
+
+        # Directory that contains this wrapper (the folder holding `.mvn/wrapper`), relative to the
+        # repo root. "." for a root wrapper, e.g. "submodule" for a module wrapper. Derived from the
+        # properties file so multi-module repos update the correct wrapper in place.
+        sig { returns(String) }
+        def wrapper_dir
+          @wrapper_dir ||= T.let(
+            begin
+              name = wrapper_properties_file&.name.to_s
+              dir = name.sub(%r{/?#{Regexp.escape(WRAPPER_PROPERTIES_RELATIVE)}\z}, "")
+              dir.empty? ? "." : dir
+            end,
+            T.nilable(String)
+          )
+        end
+
+        sig { params(path: String).returns(String) }
+        def in_wrapper_dir(path)
+          wrapper_dir == "." ? path : File.join(wrapper_dir, path)
+        end
+
+        sig { returns(String) }
+        def properties_path
+          in_wrapper_dir(WRAPPER_PROPERTIES_RELATIVE)
+        end
+
+        sig { returns(String) }
+        def jar_path
+          in_wrapper_dir(JAR_RELATIVE)
+        end
+
+        sig { returns(String) }
+        def downloader_path
+          in_wrapper_dir(DOWNLOADER_RELATIVE)
         end
 
         # Assembles all updated files: properties, scripts, and the type-specific artifact.
@@ -352,11 +383,11 @@ module Dependabot
         # Returns a DependencyFile for the updated maven-wrapper.properties, or [] if absent.
         sig { returns(T::Array[DependencyFile]) }
         def collect_properties_file
-          return [] unless File.exist?(WRAPPER_PROPERTIES_RELATIVE)
+          return [] unless File.exist?(properties_path)
 
           [DependencyFile.new(
-            name: WRAPPER_PROPERTIES_RELATIVE,
-            content: File.read(WRAPPER_PROPERTIES_RELATIVE),
+            name: properties_path,
+            content: File.read(properties_path),
             directory: wrapper_properties_file&.directory || "/"
           )]
         end
@@ -366,11 +397,12 @@ module Dependabot
         sig { returns(T::Array[DependencyFile]) }
         def collect_script_files
           ALL_SCRIPTS.filter_map do |script|
-            next unless File.exist?(script)
+            script_file = in_wrapper_dir(script)
+            next unless File.exist?(script_file)
 
             file = DependencyFile.new(
-              name: script,
-              content: File.read(script),
+              name: script_file,
+              content: File.read(script_file),
               directory: wrapper_properties_file&.directory || "/"
             )
             file.mode = DependencyFile::Mode::EXECUTABLE if UNIX_SCRIPTS.include?(script)
@@ -384,20 +416,20 @@ module Dependabot
         def collect_artifact_file(dist_type)
           case dist_type
           when "bin", "script"
-            return [] unless File.exist?(JAR_RELATIVE)
+            return [] unless File.exist?(jar_path)
 
             [DependencyFile.new(
-              name: JAR_RELATIVE,
-              content: Base64.encode64(File.binread(JAR_RELATIVE)),
+              name: jar_path,
+              content: Base64.encode64(File.binread(jar_path)),
               content_encoding: DependencyFile::ContentEncoding::BASE64,
               directory: wrapper_properties_file&.directory || "/"
             )]
           when "source"
-            return [] unless File.exist?(DOWNLOADER_RELATIVE)
+            return [] unless File.exist?(downloader_path)
 
             [DependencyFile.new(
-              name: DOWNLOADER_RELATIVE,
-              content: File.read(DOWNLOADER_RELATIVE),
+              name: downloader_path,
+              content: File.read(downloader_path),
               directory: wrapper_properties_file&.directory || "/"
             )]
           else
@@ -405,11 +437,18 @@ module Dependabot
           end
         end
 
-        # Memoized lookup of the maven-wrapper.properties DependencyFile.
+        # Memoized lookup of the maven-wrapper.properties DependencyFile for THIS wrapper. Prefers the
+        # file referenced by the dependency's requirements so multi-module repos pick the right one.
         sig { returns(T.nilable(DependencyFile)) }
         def wrapper_properties_file
           @wrapper_properties_file ||= T.let(
-            @dependency_files.find { |f| f.name.end_with?("maven-wrapper.properties") },
+            begin
+              req_file = dependency.requirements
+                                   .find { |r| r.dig(:source, :type) == Distributions::DISTRIBUTION_DEPENDENCY_TYPE }
+                                   &.fetch(:file, nil)
+              @dependency_files.find { |f| f.name == req_file } ||
+                @dependency_files.find { |f| f.name.end_with?("maven-wrapper.properties") }
+            end,
             T.nilable(Dependabot::DependencyFile)
           )
         end

--- a/maven/lib/dependabot/maven/native_helpers.rb
+++ b/maven/lib/dependabot/maven/native_helpers.rb
@@ -27,6 +27,8 @@ module Dependabot
         params(file_name: String).void
       end
       def self.run_mvn_dependency_tree_plugin(file_name)
+        raise DependabotError, "Could not resolve maven-dependency-plugin version" unless DEPENDENCY_PLUGIN_VERSION
+
         proxy_url = URI.parse(ENV.fetch("HTTPS_PROXY"))
         stdout, _, status = Open3.capture3(
           { "PROXY_HOST" => proxy_url.host },
@@ -66,10 +68,11 @@ module Dependabot
           wrapper_plugin_version: String,
           env: T::Hash[String, String],
           distribution_type: String,
-          extra_args: T::Array[String]
+          extra_args: T::Array[String],
+          cwd: T.nilable(String)
         ).void
       end
-      def self.run_mvnw_wrapper(version:, wrapper_plugin_version:, env:, distribution_type:, extra_args: [])
+      def self.run_mvnw_wrapper(version:, wrapper_plugin_version:, env:, distribution_type:, extra_args: [], cwd: nil)
         # Use the fully-qualified plugin goal so the exact plugin version is
         # invoked regardless of the project's plugin group configuration.
         plugin_goal = "org.apache.maven.plugins:maven-wrapper-plugin:" \
@@ -83,7 +86,8 @@ module Dependabot
         ] + extra_args
 
         cmd = Shellwords.join(["mvn"] + standard_args)
-        SharedHelpers.run_shell_command(cmd, env: env)
+        run_cwd = cwd && cwd != "." ? cwd : nil
+        SharedHelpers.run_shell_command(cmd, env: env, cwd: run_cwd)
       end
     end
   end

--- a/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
+++ b/maven/lib/dependabot/maven/update_checker/requirements_updater.rb
@@ -56,10 +56,11 @@ module Dependabot
           requirements.map do |req|
             # Wrapper property requirements (distributionUrl, wrapperVersion,
             # wrapperUrl) live in maven-wrapper.properties, not in a pom.xml.
-            # They must not go through POM XML update logic
-            # instead, only the version inside the requirement is updated.
+            # They must not go through POM XML update logic; instead we bump the
+            # requirement and keep the version metadata / artifact URL the
+            # FileUpdater reads in sync with it.
             if req.dig(:source, :type) == Distributions::DISTRIBUTION_DEPENDENCY_TYPE
-              next req.merge(requirement: T.must(latest_version).to_s)
+              next bump_distribution_requirement(req)
             end
 
             next req if req.fetch(:requirement).nil?
@@ -79,6 +80,53 @@ module Dependabot
 
         sig { returns(T::Array[T::Hash[Symbol, T.untyped]]) }
         attr_reader :requirements
+
+        # Bumps a wrapper (maven-wrapper.properties) requirement. As well as the requirement
+        # string, it updates the fields the FileUpdater actually reads so a real update regenerates
+        # the *new* release rather than the old one:
+        #   - distributionUrl  -> metadata[:distribution_version] and the versioned source url
+        #   - wrapperVersion   -> metadata[:wrapper_version]
+        # The wrapperUrl tag-along requirement (present only on the distribution dependency) is left
+        # otherwise untouched, since bumping the distribution does not change the wrapper JAR.
+        sig { params(req: T::Hash[Symbol, T.untyped]).returns(T::Hash[Symbol, T.untyped]) }
+        def bump_distribution_requirement(req)
+          new_version = T.must(latest_version).to_s
+          old_version = req[:requirement]
+          updated = req.merge(requirement: new_version)
+
+          case req.dig(:source, :property)
+          when "distributionUrl"
+            updated = merge_metadata_version(updated, :distribution_version, new_version)
+            updated = merge_source_url(updated, old_version, new_version)
+          when "wrapperVersion"
+            updated = merge_metadata_version(updated, :wrapper_version, new_version)
+          end
+
+          updated
+        end
+
+        sig do
+          params(req: T::Hash[Symbol, T.untyped], key: Symbol, new_version: String)
+            .returns(T::Hash[Symbol, T.untyped])
+        end
+        def merge_metadata_version(req, key, new_version)
+          metadata = req[:metadata]
+          return req unless metadata.is_a?(Hash)
+
+          req.merge(metadata: metadata.merge(key => new_version))
+        end
+
+        sig do
+          params(req: T::Hash[Symbol, T.untyped], old_version: T.nilable(String), new_version: String)
+            .returns(T::Hash[Symbol, T.untyped])
+        end
+        def merge_source_url(req, old_version, new_version)
+          source = req[:source]
+          url = source.is_a?(Hash) ? source[:url] : nil
+          return req unless url && old_version && !old_version.empty?
+
+          req.merge(source: source.merge(url: url.sub(old_version, new_version)))
+        end
 
         sig { returns(T.nilable(Version)) }
         attr_reader :latest_version

--- a/maven/spec/dependabot/maven/file_parser/wrapper_mojo_spec.rb
+++ b/maven/spec/dependabot/maven/file_parser/wrapper_mojo_spec.rb
@@ -143,12 +143,29 @@ RSpec.describe Dependabot::Maven::FileParser::WrapperMojo do
       let(:script_content) { fixture("wrapper_files", "mvnw-3.3.0") }
       let(:mvnw_file) { make_properties_file("mvnw", script_content) }
 
-      it "defaults distributionType to bin" do
-        expect(props.distribution_type).to eq("bin")
+      it "defaults distributionType to the plugin default (only-script) when no wrapperUrl is present" do
+        expect(props.distribution_type).to eq("only-script")
       end
 
       it "reads wrapper_version from the script file" do
         expect(props.wrapper_version).to eq("3.3.0")
+      end
+    end
+
+    context "with missing distributionType but a legacy wrapperUrl (JAR-based setup)" do
+      subject(:props) { described_class.load_properties(content, script_files: [mvnw_file]) }
+
+      let(:content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.6/apache-maven-3.9.6-bin.zip\n" \
+          "wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/" \
+          "maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar\n"
+      end
+      let(:script_content) { fixture("wrapper_files", "mvnw-3.3.0") }
+      let(:mvnw_file) { make_properties_file("mvnw", script_content) }
+
+      it "defaults distributionType to bin for legacy wrapperUrl setups" do
+        expect(props.distribution_type).to eq("bin")
       end
     end
 

--- a/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater/wrapper_updater_spec.rb
@@ -376,5 +376,174 @@ RSpec.describe Dependabot::Maven::FileUpdater::WrapperUpdater do
         expect(names).not_to include(".mvn/wrapper/maven-wrapper.jar")
       end
     end
+
+    # Integrity checksums are restored from the URLs in the regenerated properties file, independently
+    # of which coordinate was bumped, so a wrapperVersion-only bump still keeps the
+    # distributionSha256Sum / wrapperSha256Sum that the original file tracked.
+    context "when the wrapper plugin is bumped and the original tracked checksums" do
+      include_context "with native helpers stubbed"
+
+      let(:artifact_bytes) { "fake-artifact-bytes" }
+      let(:expected_sha) { Digest::SHA256.hexdigest(artifact_bytes) }
+      let(:dist_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip"
+      end
+      let(:wrapper_url) do
+        "https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar"
+      end
+      let(:properties_content) do
+        <<~PROPS
+          distributionUrl=#{dist_url}
+          distributionType=only-script
+          wrapperUrl=#{wrapper_url}
+          wrapperVersion=3.3.3
+          distributionSha256Sum=0000000000000000000000000000000000000000000000000000000000000000
+          wrapperSha256Sum=1111111111111111111111111111111111111111111111111111111111111111
+        PROPS
+      end
+
+      # A wrapper-plugin (wrapperVersion) dependency carries neither checksum in its requirements.
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.apache.maven.wrapper:maven-wrapper",
+          version: "3.3.4",
+          previous_version: "3.3.3",
+          requirements: [{
+            requirement: "3.3.4",
+            file: ".mvn/wrapper/maven-wrapper.properties",
+            source: { type: "maven-distribution", property: "wrapperVersion" },
+            groups: [],
+            metadata: { wrapper_version: "3.3.4", distribution_version: "3.9.9", distribution_type: "only-script",
+                        include_debug_script: false }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      before do
+        response = Struct.new(:status, :body).new(200, artifact_bytes)
+        allow(Dependabot::RegistryClient).to receive(:get).and_return(response)
+      end
+
+      it "restores the distribution checksum recomputed from the artifact" do
+        props = updater.update_files(buildfile)
+                       .find { |f| f.name == ".mvn/wrapper/maven-wrapper.properties" }
+        expect(props&.content).to include("distributionSha256Sum=#{expected_sha}")
+      end
+
+      it "restores the wrapper checksum recomputed from the artifact" do
+        props = updater.update_files(buildfile)
+                       .find { |f| f.name == ".mvn/wrapper/maven-wrapper.properties" }
+        expect(props&.content).to include("wrapperSha256Sum=#{expected_sha}")
+      end
+    end
+
+    context "when the original properties file had no checksums" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+
+      it "does not add any checksum properties" do
+        props = updater.update_files(buildfile)
+                       .find { |f| f.name == ".mvn/wrapper/maven-wrapper.properties" }
+        expect(props&.content).not_to match(/Sha256Sum/)
+      end
+
+      it "never downloads an artifact to compute a checksum" do
+        allow(Dependabot::RegistryClient).to receive(:get)
+        updater.update_files(buildfile)
+        expect(Dependabot::RegistryClient).not_to have_received(:get)
+      end
+    end
+
+    # A wrapper that lives beside a child pom is regenerated in place, not at the repo root.
+    context "when the wrapper lives in a module (non-root)" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+      let(:properties_file) { make_file("module/.mvn/wrapper/maven-wrapper.properties", properties_content) }
+      let(:mvnw_file) { make_file("module/mvnw", "#!/bin/sh\nexec mvn \"$@\"\n") }
+      let(:dependency_files) { [properties_file, mvnw_file] }
+      let(:buildfile) { make_file("module/pom.xml", "<project></project>") }
+
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.apache.maven:apache-maven",
+          version: "3.9.9",
+          previous_version: "3.9.8",
+          requirements: [{
+            requirement: "3.9.9",
+            file: "module/.mvn/wrapper/maven-wrapper.properties",
+            source: {
+              type: "maven-distribution",
+              url: "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+                   "3.9.9/apache-maven-3.9.9-bin.zip",
+              property: "distributionUrl"
+            },
+            groups: [],
+            metadata: { packaging_type: "pom", wrapper_version: "3.3.4", distribution_type: "only-script",
+                        distribution_version: "3.9.9", include_debug_script: false }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      it "runs the native command in the module directory" do
+        received = {}
+        allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+        updater.update_files(buildfile)
+        expect(received[:cwd]).to eq("module")
+      end
+
+      it "emits module-prefixed file names" do
+        names = updater.update_files(buildfile).map(&:name)
+        expect(names).to include("module/.mvn/wrapper/maven-wrapper.properties")
+      end
+    end
+
+    # The plugin's user property is `includeDebug` (the internal field is includeDebugScript). Passing
+    # the wrong flag would silently drop the user's mvnwDebug scripts on every update.
+    context "when the wrapper includes debug scripts" do
+      include_context "with native helpers stubbed"
+
+      let(:properties_content) do
+        "distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+          "3.9.8/apache-maven-3.9.8-bin.zip\ndistributionType=only-script\nwrapperVersion=3.3.4\n"
+      end
+      let(:dependency) do
+        Dependabot::Dependency.new(
+          name: "org.apache.maven:apache-maven",
+          version: "3.9.9",
+          previous_version: "3.9.8",
+          requirements: [{
+            requirement: "3.9.9",
+            file: ".mvn/wrapper/maven-wrapper.properties",
+            source: {
+              type: "maven-distribution",
+              url: "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+                   "3.9.9/apache-maven-3.9.9-bin.zip",
+              property: "distributionUrl"
+            },
+            groups: [],
+            metadata: { packaging_type: "pom", wrapper_version: "3.3.4", distribution_type: "only-script",
+                        distribution_version: "3.9.9", include_debug_script: true }
+          }],
+          package_manager: "maven"
+        )
+      end
+
+      it "passes the plugin's includeDebug user property" do
+        received = {}
+        allow(Dependabot::Maven::NativeHelpers).to receive(:run_mvnw_wrapper) { |**kwargs| received = kwargs }
+        updater.update_files(buildfile)
+        expect(received[:extra_args]).to include("-DincludeDebug=true")
+      end
+    end
   end
 end

--- a/maven/spec/dependabot/maven/file_updater_spec.rb
+++ b/maven/spec/dependabot/maven/file_updater_spec.rb
@@ -1391,4 +1391,93 @@ RSpec.describe Dependabot::Maven::FileUpdater do
       end
     end
   end
+
+  # Wrapper updates are grouped per wrapper so a grouped distribution + wrapper-plugin bump
+  # regenerates each wrapper exactly once (no duplicate/conflicting files), and a module wrapper is
+  # regenerated against its own pom rather than the repo root.
+  describe "#updated_dependency_files with the maven wrapper experiment" do
+    let(:wrapper_updater_class) { Dependabot::Maven::FileUpdater::WrapperUpdater }
+    let(:marker_file) do
+      Dependabot::DependencyFile.new(name: ".mvn/wrapper/maven-wrapper.properties", content: "updated", directory: "/")
+    end
+    let(:wrapper_double) { instance_double(wrapper_updater_class, update_files: [marker_file]) }
+
+    let(:properties_name) { ".mvn/wrapper/maven-wrapper.properties" }
+    let(:properties_file) { Dependabot::DependencyFile.new(name: properties_name, content: "distributionUrl=x\n") }
+    let(:dependency_files) { [pom, properties_file] }
+
+    let(:distribution_dep) do
+      Dependabot::Dependency.new(
+        name: "org.apache.maven:apache-maven",
+        version: "3.9.11",
+        previous_version: "3.9.9",
+        requirements: [{
+          requirement: "3.9.11",
+          file: properties_name,
+          source: { type: "maven-distribution", property: "distributionUrl", url: "https://example/3.9.11.zip" },
+          groups: [],
+          metadata: { distribution_version: "3.9.11", wrapper_version: "3.3.5" }
+        }],
+        package_manager: "maven"
+      )
+    end
+    let(:wrapper_dep) do
+      Dependabot::Dependency.new(
+        name: "org.apache.maven.wrapper:maven-wrapper",
+        version: "3.3.5",
+        previous_version: "3.3.4",
+        requirements: [{
+          requirement: "3.3.5",
+          file: properties_name,
+          source: { type: "maven-distribution", property: "wrapperVersion" },
+          groups: [],
+          metadata: { distribution_version: "3.9.11", wrapper_version: "3.3.5" }
+        }],
+        package_manager: "maven"
+      )
+    end
+    let(:dependencies) { [distribution_dep, wrapper_dep] }
+
+    before do
+      Dependabot::Experiments.register(:maven_wrapper_updater, true)
+      allow(wrapper_updater_class).to receive(:new).and_return(wrapper_double)
+    end
+
+    it "regenerates the shared wrapper exactly once for a grouped update" do
+      updater.updated_dependency_files
+      expect(wrapper_updater_class).to have_received(:new).once
+    end
+
+    it "does not emit the same wrapper file twice" do
+      names = updater.updated_dependency_files.map(&:name)
+      expect(names.count(properties_name)).to eq(1)
+    end
+
+    it "passes both resolved target versions to the single generator" do
+      captured = nil
+      allow(wrapper_updater_class).to receive(:new) do |**kwargs|
+        captured = kwargs
+        wrapper_double
+      end
+      updater.updated_dependency_files
+      expect(captured).to include(distribution_version: "3.9.11", wrapper_version: "3.3.5")
+    end
+
+    context "when the wrapper lives in a module (non-root)" do
+      let(:properties_name) { "module/.mvn/wrapper/maven-wrapper.properties" }
+      let(:module_pom) { Dependabot::DependencyFile.new(name: "module/pom.xml", content: "<project></project>") }
+      let(:dependency_files) { [pom, module_pom, properties_file] }
+      let(:dependencies) { [distribution_dep] }
+
+      it "selects the module pom as the build file" do
+        captured = nil
+        allow(wrapper_double).to receive(:update_files) do |bf|
+          captured = bf
+          [marker_file]
+        end
+        updater.updated_dependency_files
+        expect(captured.name).to eq("module/pom.xml")
+      end
+    end
+  end
 end

--- a/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
+++ b/maven/spec/dependabot/maven/update_checker/requirements_updater_spec.rb
@@ -185,5 +185,75 @@ RSpec.describe Dependabot::Maven::UpdateChecker::RequirementsUpdater do
         end
       end
     end
+
+    # Wrapper requirements (maven-wrapper.properties) live outside the pom. The FileUpdater reads the
+    # target version from metadata[:distribution_version] / metadata[:wrapper_version] and the source
+    # url, so the RequirementsUpdater must keep those in sync with the bumped :requirement — otherwise
+    # the wrapper is regenerated for the old version.
+    context "when the requirement is a wrapper distribution requirement" do
+      subject(:updated) { updater.updated_requirements.first }
+
+      context "when bumping a distributionUrl requirement" do
+        let(:latest_version) { version_class.new("3.9.11") }
+        let(:requirements) do
+          [{
+            file: ".mvn/wrapper/maven-wrapper.properties",
+            requirement: "3.9.9",
+            groups: [],
+            source: {
+              type: "maven-distribution",
+              property: "distributionUrl",
+              url: "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+                   "3.9.9/apache-maven-3.9.9-bin.zip"
+            },
+            metadata: { distribution_version: "3.9.9", wrapper_version: "3.3.4" }
+          }]
+        end
+
+        it "bumps the requirement string" do
+          expect(updated[:requirement]).to eq("3.9.11")
+        end
+
+        it "updates metadata[:distribution_version] to the new version" do
+          expect(updated.dig(:metadata, :distribution_version)).to eq("3.9.11")
+        end
+
+        it "rewrites the versioned source url" do
+          expect(updated.dig(:source, :url)).to eq(
+            "https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/" \
+            "3.9.11/apache-maven-3.9.11-bin.zip"
+          )
+        end
+
+        it "leaves the unrelated wrapper_version metadata untouched" do
+          expect(updated.dig(:metadata, :wrapper_version)).to eq("3.3.4")
+        end
+      end
+
+      context "when bumping a wrapperVersion requirement" do
+        let(:latest_version) { version_class.new("3.3.4") }
+        let(:requirements) do
+          [{
+            file: ".mvn/wrapper/maven-wrapper.properties",
+            requirement: "3.3.3",
+            groups: [],
+            source: { type: "maven-distribution", property: "wrapperVersion" },
+            metadata: { distribution_version: "3.9.9", wrapper_version: "3.3.3" }
+          }]
+        end
+
+        it "bumps the requirement string" do
+          expect(updated[:requirement]).to eq("3.3.4")
+        end
+
+        it "updates metadata[:wrapper_version] to the new version" do
+          expect(updated.dig(:metadata, :wrapper_version)).to eq("3.3.4")
+        end
+
+        it "does not synthesise a source url" do
+          expect(updated.dig(:source, :url)).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR targets your `maven-wrapper` branch (PR dependabot/dependabot-core#14812) and applies a
set of fixes to the Maven Wrapper updater. The goal is to make the wrapper regeneration correct
in production and to bring it in line with two references: the already-shipped **Gradle** wrapper
updater, and the **official `maven-wrapper-plugin`** documentation/source.

At a high level, the updater currently works in the specs (which hand-build fresh metadata) but
diverges from what `RequirementsUpdater` actually produces and from how the native plugin behaves,
so a few paths silently produce the wrong output. The changes below fix those.

**Bug fixes**
- **Version propagation** – bump `metadata[:distribution_version]`/`[:wrapper_version]` and the
  versioned `source[:url]`, not just `:requirement`, so the wrapper is regenerated for the *new*
  version instead of the old one.
- **Checksums** – restore `distributionSha256Sum`/`wrapperSha256Sum` independently of which
  coordinate was bumped, so a wrapper-plugin bump no longer silently drops the integrity checksums.
- **Replaces-base registries** – use `Credential#replaces_base?` (the hyphenated `replaces-base`
  key is deleted in the constructor), so mirrors set `MVNW_REPOURL` correctly.
- **Root wrapper** – fix the directory regex so a repo-root wrapper resolves its `mvnw` scripts.
- **Grouped / multi-module updates** – regenerate each wrapper exactly once (no duplicate,
  conflicting files) and update module wrappers against their own `pom.xml` rather than the root.
- **Debug scripts** – pass the plugin's real user property `-DincludeDebug=true` (was
  `-DincludeDebugScript`, which the plugin ignores), so `mvnwDebug` scripts are preserved.
- **distributionType default** – default to `only-script` (the plugin default since 3.2.0),
  falling back to `bin` only for legacy `wrapperUrl` (JAR-based) setups.

**Housekeeping**
- Remove dead `username`/`password`/Basic-auth code: core runs on credentials-metadata (creds are
  stripped before core sees them) and the proxy injects registry auth — matching how Gradle's
  wrapper updater works.
- Bound the properties regex to clear the CodeQL polynomial-regex alert; guard a missing
  dependency-plugin version so it fails loudly.
- `smoke.yml`: route all smoke-test repo/branch references through single `SMOKE_TEST_REPO` /
  `SMOKE_TEST_BRANCH` env vars (**defaults unchanged — still your fork/branch**).

### Anything you want to highlight for special attention from reviewers?

- The single most useful framing: the shipped **Gradle** wrapper updater already solved most of
  these problems, and the Maven code diverged exactly at the buggy points — so the fixes mostly
  align Maven with Gradle and with the official plugin behaviour.
- The plugin behaviours (`-DincludeDebug`, `only-script` default, checksum user-properties) were
  verified against the official docs and `apache/maven-wrapper` source, not assumed.
- **`smoke.yml` is intentionally left pointing at your fork** (`yeikel/smoke-tests` + `maven-wrapper`)
  so your integration testing keeps working. I only de-duplicated the hard-coded literals into two
  env vars; before merge you can flip lines 17–18 (or set repo variables) to `dependabot/smoke-tests`
  + `main`.

### How will you know you've accomplished your goal?

- New/updated specs cover each fix: version propagation into metadata + source url, checksum
  restoration on a wrapper-plugin bump, grouped/module updates running the generator once against
  the right pom, `-DincludeDebug=true`, and the `only-script` vs legacy-`bin` default.
- Note: I could not run the full Ruby suite / Sorbet locally (they run in Docker). Files pass
  `ruby -c` and standalone RuboCop; please run `bin/test maven ...` in CI to confirm.

### Checklist

- [ ] I have run the complete test suite to ensure all tests and linters pass. <!-- Docker-only; validated via ruby -c + RuboCop locally, needs CI -->
- [x] I have thoroughly tested my code changes to ensure they work as expected, including adding additional tests for new functionality.
- [x] I have written clear and descriptive commit messages.
- [x] I have provided a detailed description of the changes in the pull request, including the problem it addresses, how it fixes the problem, and any relevant details about the implementation.
- [x] I have ensured that the code is well-documented and easy to understand.
